### PR TITLE
Fixing a problem in the console application regarding language

### DIFF
--- a/OSDBcmd/Program.cs
+++ b/OSDBcmd/Program.cs
@@ -62,6 +62,8 @@ namespace OSDBcmd {
 
 		static void DownloadSubtitle(string movieFileName, bool lucky, IList<string> languages) {
 			var systemLanguage = GetSystemLanguage();
+			if (!languages.Contains(systemLanguage)) 
+		        	languages.Add(systemLanguage);
 			using (var osdb = Osdb.Login(systemLanguage, "OS Test User Agent")) {
 				var subtitles = osdb.SearchSubtitlesFromFile(languages.Aggregate( (a,b) => a + "," +b ),movieFileName);
 


### PR DESCRIPTION
Fixing a bug where if the console was called without any languange, a InvalidOperationException was thrown.

Added the system language to the list of languages
